### PR TITLE
[WIP] Improve build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM circleci/openjdk:8-jdk as build
+WORKDIR /home/circleci
+# Install atlassian-plugin-sdk
+RUN wget -nv https://packages.atlassian.com/api/gpg/key/public \
+    && sudo apt-key add public \
+    && sudo sh -c 'echo "deb https://packages.atlassian.com/atlassian-sdk-deb stable contrib" >> /etc/apt/sources.list' \
+    && sudo apt-get -q -y install apt-transport-https \
+    && sudo apt-get -q update \
+    && sudo apt-get -q -y install atlassian-plugin-sdk
+COPY --chown=circleci pom.xml .
+# Get dependencies
+RUN atlas-mvn --batch-mode dependency:go-offline
+COPY --chown=circleci src src
+# Build packages
+RUN atlas-package --batch-mode \
+    && mkdir artifacts/ \
+    && mv target/prism-* artifacts/
+# Save artifacts in small alpine image
+FROM alpine
+COPY --from=build --chown=root /home/circleci/artifacts /artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
                     -->
                     <enableQuickReload>true</enableQuickReload>
                     <enableFastdev>false</enableFastdev>
+                    <compressResources>false</compressResources>
                     <!-- See here for an explanation of default instructions: -->
                     <!-- https://developer.atlassian.com/docs/advanced-topics/configuration-of-instructions-in-atlassian-plugins -->
                     <instructions>


### PR DESCRIPTION
Let's try to do local build with Docker in a similar way as CircleCI build is done.
Currently `atlas-package` is failing on vanilla Prism JS/CSS (minified or development version) with errors like this:
```bash
Executing: /usr/share/atlassian-plugin-sdk-8.0.16/apache-maven-3.5.4/bin/mvn package -gs /usr/share/atlassian-plugin-sdk-8.0.16/apache-maven-3.5.4/conf/settings.xml --batch-mode
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------------< com.catawiki.jira:prism >-----------------------
[INFO] Building Prism 1.2.4
[INFO] --------------------------[ atlassian-plugin ]--------------------------
[INFO]
[INFO] --- jira-maven-plugin:8.0.0:compress-resources (default-compress-resources) @ prism ---
[INFO] Compiling javascript using YUI
[ERROR] invalid property id
	!function(s){var t=/("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/;s.languages.css={comment:/\/\*[\s\S]*?\*\//,atrule:{pattern:/@[\w-]+[\s\S]*?(?:;|(?=\s*\{))/,inside:{rule:/@[\w-]+/}},url:{pattern:RegExp("url\\((?:"+t.source+"|[^\n\r()]*)\\)","i"),inside:{function:/^url/i,punctuation:/^\(|\)$/}},selector:RegExp("[^{}\\s](?:[^{};\"']|"+t.source+")*?(?=\\s*\\{)"),string:{pattern:t,greedy:!0},property:/[-_a-z\xA0-\uFFFF][-\w\xA0-\uFFFF]*(?=\s*:)/i,important:/!important\b/i,function:/[-a-z0-9]+(?=\()/i,punctuation:/[(){};:,]/},s.languages.css.atrule.inside.rest=s.languages.css;var e=s.languages.markup;e&&(e.tag.addInlined("style","css"),s.languages.insertBefore("inside","attr-value",{"style-attr":{pattern:/\s*style=("|')(?:\\[\s\S]|(?!\1)[^\\])*\1/i,inside:{"attr-name":{pattern:/^\s*style/i,inside:e.tag.inside},punctuation:/^\s*=\s*['"]|['"]\s*$/,"attr-value":{pattern:/.+/i,inside:s.languages.css}},alias:"language-css"}},e.tag))}(Prism);
[ERROR] illegal character
	!function(s){var t=/("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/;s.languages.css={comment:/\/\*[\s\S]*?\*\//,atrule:{pattern:/@[\w-]+[\s\S]*?(?:;|(?=\s*\{))/,inside:{rule:/@[\w-]+/}},url:{pattern:RegExp("url\\((?:"+t.source+"|[^\n\r()]*)\\)","i"),inside:{function:/^url/i,punctuation:/^\(|\)$/}},selector:RegExp("[^{}\\s](?:[^{};\"']|"+t.source+")*?(?=\\s*\\{)"),string:{pattern:t,greedy:!0},property:/[-_a-z\xA0-\uFFFF][-\w\xA0-\uFFFF]*(?=\s*:)/i,important:/!important\b/i,function:/[-a-z0-9]+(?=\()/i,punctuation:/[(){};:,]/},s.languages.css.atrule.inside.rest=s.languages.css;var e=s.languages.markup;e&&(e.tag.addInlined("style","css"),s.languages.insertBefore("inside","attr-value",{"style-attr":{pattern:/\s*style=("|')(?:\\[\s\S]|(?!\1)[^\\])*\1/i,inside:{"attr-name":{pattern:/^\s*style/i,inside:e.tag.inside},punctuation:/^\s*=\s*['"]|['"]\s*$/,"attr-value":{pattern:/.+/i,inside:s.languages.css}},alias:"language-css"}},e.tag))}(Prism);
[ERROR] syntax error
	!function(s){var t=/("|')(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/;s.languages.css={comment:/\/\*[\s\S]*?\*\//,atrule:{pattern:/@[\w-]+[\s\S]*?(?:;|(?=\s*\{))/,inside:{rule:/@[\w-]+/}},url:{pattern:RegExp("url\\((?:"+t.source+"|[^\n\r()]*)\\)","i"),inside:{function:/^url/i,punctuation:/^\(|\)$/}},selector:RegExp("[^{}\\s](?:[^{};\"']|"+t.source+")*?(?=\\s*\\{)"),string:{pattern:t,greedy:!0},property:/[-_a-z\xA0-\uFFFF][-\w\xA0-\uFFFF]*(?=\s*:)/i,important:/!important\b/i,function:/[-a-z0-9]+(?=\()/i,punctuation:/[(){};:,]/},s.languages.css.atrule.inside.rest=s.languages.css;var e=s.languages.markup;e&&(e.tag.addInlined("style","css"),s.languages.insertBefore("inside","attr-value",{"style-attr":{pattern:/\s*style=("|')(?:\\[\s\S]|(?!\1)[^\\])*\1/i,inside:{"attr-name":{pattern:/^\s*style/i,inside:e.tag.inside},punctuation:/^\s*=\s*['"]|['"]\s*$/,"attr-value":{pattern:/.+/i,inside:s.languages.css}},alias:"language-css"}},e.tag))}(Prism);
```
This can be mitigated with disabling compression in `pom.xml` (https://stackoverflow.com/questions/27731296/yui-fails-to-compress-in-confluence-plugin#37291669) or possibly by disabling YUI minification with `-Datlassian.webresource.disable.minification=true` (https://developer.atlassian.com/server/framework/atlassian-sdk/supporting-minification-of-javascript-and-css-resources/)