### PR TITLE
Remove all Catawiki branding from the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2019, Catawiki
+Copyright (c) 2020, Prism Project Authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
 ## Server and Datacenter app
-Catawiki B.V. DOES NOT receive or collect any information you enter while using this app.
+Prism App and it's developers DO NOT receive or collect any information you enter while using this app.
 
 ## Atlassian Marketplace
 This app is provided free of charge on the Atlassian Marketplace or through GitHub. If you install this app from the marketplace, Atlassian Marketplace may provide us with contact information. We don’t use this information and will only see this on the Marketplace backend if we can not evade that particular page.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<a href="https://marketplace.atlassian.com/plugins/com.catawiki.jira.prism"><img src="src/main/resources/images/logo.svg"/></a>
+<a href="https://marketplace.atlassian.com/plugins/com.github.jira.prism"><img src="src/main/resources/images/logo.svg"/></a>
 
-<a href="https://marketplace.atlassian.com/plugins/com.catawiki.jira.prism"><img width="150" src="src/main/resources/images/marketplace.png"/></a>
-
-[![CircleCI](https://circleci.com/gh/catawiki/Prism.svg?style=svg)](https://circleci.com/gh/catawiki/Prism)
+<a href="https://marketplace.atlassian.com/plugins/com.github.jira.prism"><img width="150" src="src/main/resources/images/marketplace.png"/></a>
 
 Prism is a `{code}` macro plugin for Atlassian Jira.
 
@@ -105,7 +103,7 @@ Syntax: `highlight=<line(s)>,<range>,...` or `hl=<line(s)>,<range>,...`
 Syntax: `cmd=<user>@<host>[><output line(s),<ranges>,...]` or `commandline=<user>@<host>[><output line(s),<ranges>,...]`
 
 ```
-{code:bash|cmd=siavash@catawiki>2,5-30}
+{code:bash|cmd=siavash@localhost>2,5-30}
 ...
 {code}
 ```
@@ -116,7 +114,7 @@ Visual editing in Rich Text Editor is not fully supported. While you don't have 
 ## Notes
 This plugin uses a slightly modified version of [Prism](http://prismjs.com/) to fix JS compile issues with Atlassian Plugin SDK.
 
-This plugin is released without any support, if you want to add a new feature or fix a bug feel free to [submit a PR](https://github.com/catawiki/Prism/pull/new/master).
+This plugin is released without any support, if you want to add a new feature or fix a bug feel free to [submit a PR](https://github.com/siavashs/Prism/pull/new/master).
 
 Also check [this Jira Server issue](https://jira.atlassian.com/browse/JRASERVER-21067) regarding `{code}` macro limitations and why this plugin was developed.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.catawiki.jira</groupId>
+    <groupId>com.github.jira</groupId>
     <artifactId>prism</artifactId>
     <version>1.2.4</version>
     <organization>
-        <name>Catawiki B.V.</name>
-        <url>https://www.catawiki.com/</url>
+        <name>Prism Project</name>
+        <url>https://prismjira.app/</url>
     </organization>
     <name>Prism</name>
     <description>Code syntax highlighting plugin for Atlassian Jira.</description>
@@ -108,7 +108,7 @@
                       -->
                         <!-- Add package to export here -->
                         <Export-Package>
-                            com.catawiki.jira.prism,
+                            com.github.jira.prism,
                         </Export-Package>
                         <!-- Add package import here -->
                         <Import-Package>

--- a/src/main/java/com/github/jira/prism/Code.java
+++ b/src/main/java/com/github/jira/prism/Code.java
@@ -1,4 +1,4 @@
-package com.catawiki.jira.prism;
+package com.github.jira.prism;
 
 import com.atlassian.jira.template.soy.SoyTemplateRendererProvider;
 import com.atlassian.renderer.RenderContext;
@@ -96,7 +96,7 @@ public class Code extends BaseMacro {
 
         try {
             return this.soyTemplateRenderer.render(
-                    "com.catawiki.jira.prism:handler",
+                    "com.github.jira.prism:handler",
                     "Prism.Macros.Code.html",
                     templateParams.build());
         } catch (SoyException e) {

--- a/src/main/java/com/github/jira/prism/Init.java
+++ b/src/main/java/com/github/jira/prism/Init.java
@@ -1,4 +1,4 @@
-package com.catawiki.jira.prism;
+package com.github.jira.prism;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -44,13 +44,13 @@
     </web-resource>
 
     <macro key='code' name='{code} formatting macro'
-       class='com.catawiki.jira.prism.Code'>
+       class='com.github.jira.prism.Code'>
       <description>Syntax highlighting for code blocks.</description>
       <param name="convert-selector">code-macro</param>
       <param name="convert-function">Prism.Macros.Code.convert</param>
     </macro>
 
-    <component key="init" class="com.catawiki.jira.prism.Init"
+    <component key="init" class="com.github.jira.prism.Init"
       name="Prism initialization support">
       <description>Helper module to automatic disabling / enabling of Jira standard code macro on
         installation or enabling / deinstallation or disabling of Prism Syntax Highlighter plugin</description>


### PR DESCRIPTION
- Remove all Catawiki branding from the project
- Use http://prismjira.app domain as vendor website
- Catawiki will hold the copyright till 2019