### PR TITLE
Temporary fix for line highlight plugin offset

### DIFF
--- a/src/main/resources/js/prism.js
+++ b/src/main/resources/js/prism.js
@@ -13873,7 +13873,7 @@ Prism.languages.xojo = {
 				var endNode = Prism.plugins.lineNumbers.getLine(pre, end);
 
 				if (startNode) {
-					var top = startNode.offsetTop + 'px';
+					var top = startNode.offsetTop - offset * lineHeight + 'px';
 					mutateActions.push(function () {
 						line.style.top = top;
 					});


### PR DESCRIPTION
Temporary fix for line highlight plugin offset until it's fixed by upstream.
Fixes #27
Upstream PR https://github.com/PrismJS/prism/pull/2237