### PR TITLE
Restore initial java package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<a href="https://marketplace.atlassian.com/plugins/com.github.jira.prism"><img src="src/main/resources/images/logo.svg"/></a>
+<a href="https://marketplace.atlassian.com/plugins/com.catawiki.jira.prism"><img src="src/main/resources/images/logo.svg"/></a>
 
-<a href="https://marketplace.atlassian.com/plugins/com.github.jira.prism"><img width="150" src="src/main/resources/images/marketplace.png"/></a>
+<a href="https://marketplace.atlassian.com/plugins/com.catawiki.jira.prism"><img width="150" src="src/main/resources/images/marketplace.png"/></a>
 
 Prism is a `{code}` macro plugin for Atlassian Jira.
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.jira</groupId>
+    <groupId>com.catawiki.jira</groupId>
     <artifactId>prism</artifactId>
     <version>1.3.0</version>
     <organization>
@@ -118,7 +118,7 @@
                       -->
                         <!-- Add package to export here -->
                         <Export-Package>
-                            com.github.jira.prism,
+                            com.catawiki.jira.prism,
                         </Export-Package>
                         <!-- Add package import here -->
                         <Import-Package>

--- a/src/main/java/com/catawiki/jira/prism/Code.java
+++ b/src/main/java/com/catawiki/jira/prism/Code.java
@@ -1,4 +1,4 @@
-package com.github.jira.prism;
+package com.catawiki.jira.prism;
 
 import com.atlassian.jira.template.soy.SoyTemplateRendererProvider;
 import com.atlassian.renderer.RenderContext;
@@ -96,7 +96,7 @@ public class Code extends BaseMacro {
 
         try {
             return this.soyTemplateRenderer.render(
-                    "com.github.jira.prism:handler",
+                    "com.catawiki.jira.prism:handler",
                     "Prism.Macros.Code.html",
                     templateParams.build());
         } catch (SoyException e) {

--- a/src/main/java/com/catawiki/jira/prism/Init.java
+++ b/src/main/java/com/catawiki/jira/prism/Init.java
@@ -1,4 +1,4 @@
-package com.github.jira.prism;
+package com.catawiki.jira.prism;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -44,13 +44,13 @@
     </web-resource>
 
     <macro key='code' name='{code} formatting macro'
-       class='com.github.jira.prism.Code'>
+       class='com.catawiki.jira.prism.Code'>
       <description>Syntax highlighting for code blocks.</description>
       <param name="convert-selector">code-macro</param>
       <param name="convert-function">Prism.Macros.Code.convert</param>
     </macro>
 
-    <component key="init" class="com.github.jira.prism.Init"
+    <component key="init" class="com.catawiki.jira.prism.Init"
       name="Prism initialization support">
       <description>Helper module to automatic disabling / enabling of Jira standard code macro on
         installation or enabling / deinstallation or disabling of Prism Syntax Highlighter plugin</description>


### PR DESCRIPTION
It's not possible to rename the plugin's package since updates will stop
working in marketplace.
I have already removed all the Catawiki branding and just restoring the initial
package name `com.catawiki.jira` should be fine.