### PR TITLE
Add basic WYSIWYG edit option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 .DS_Store
 
+.idea/
+/*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.catawiki.jira</groupId>
     <artifactId>prism</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <organization>
         <name>Prism Project</name>
         <url>https://prismjira.app/</url>

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -11,8 +11,8 @@
 
     <macro key="code" class="com.catawiki.jira.prism.Code" name="{code} formatting macro">
       <description>Syntax highlighting for code blocks.</description>
-      <param name="convert-selector">code-macro</param>
-      <param name="convert-function">Prism.Macros.Code.convert</param>
+      <param name="convert-selector">pre.code-macro</param>
+      <param name="convert-function">JiraPrism.Macros.Code.convert</param>
     </macro>
 
     <component key="init" class="com.catawiki.jira.prism.Init" name="Prism Plugin Initialization">

--- a/src/main/resources/soy/prism.soy
+++ b/src/main/resources/soy/prism.soy
@@ -1,4 +1,4 @@
-{namespace Prism.Macros.Code}
+{namespace JiraPrism.Macros.Code}
 
 /**
  * @param content
@@ -28,4 +28,24 @@
     {if $title}<div data-manual><b>{$title}</b></div><hr style="border: 1px dashed;" data-manual/>{/if}
     <code {if $language} class="language-{$language}" {/if}>{$content}</code>
   </pre>
+{/template}
+
+/**
+ * @param content
+ * @param parameters
+ */
+{template .wiki}
+  <pre class="code-macro" title="{$parameters}">
+    {$content}
+  </pre>
+{/template}
+
+/**
+ * @param innerMarkup
+ * @param node
+ */
+{template .convert}
+  {lb}code{if $node.title}:{$node.title}{/if}{rb}
+    {$innerMarkup|noAutoescape}
+  {lb}code{rb}
 {/template}


### PR DESCRIPTION
This should help out with #38 but still has some bugs, so I would not merge it (yet).

Overall this should help to not break code any more on visual changes. There is still a bug of escaped `{` when editing in WYSIWYG and the editor UI would need some love.

changes
* rendering of WYSIWYG without prism classes
* had to change the soy namespace as it was clashing with Prism in js (worked fine in java) and fix the selector
